### PR TITLE
Fix gremlin and replace auto_ptr

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -131,7 +131,7 @@ class client
         void handle_disruption(server_id si);
         int64_t send(pending* p);
         int64_t send_robust(pending_robust* p);
-        bool send(server_id si, std::auto_ptr<e::buffer> msg, replicant_returncode* status);
+        bool send(server_id si, std::unique_ptr<e::buffer> msg, replicant_returncode* status);
         void adopt_config(const configuration& c);
         void callback_config();
         void callback_tick();
@@ -145,7 +145,7 @@ class client
         // communication
         std::string m_conn_str;
         controller m_busybee_controller;
-        const std::auto_ptr<busybee_client> m_busybee;
+        const std::unique_ptr<busybee_client> m_busybee;
         // server selection
         uint64_t m_random_token;
         // configuration

--- a/client/pending.h
+++ b/client/pending.h
@@ -58,10 +58,10 @@ class pending
         e::error error() const { return m_error; }
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce) = 0;
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce) = 0;
         virtual bool resend_on_failure() = 0;
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up) = 0;
 
     public:

--- a/client/pending_call.cc
+++ b/client/pending_call.cc
@@ -65,7 +65,7 @@ pending_call :: ~pending_call() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_call :: request(uint64_t nonce)
 {
     e::slice obj(m_object);
@@ -77,7 +77,7 @@ pending_call :: request(uint64_t nonce)
                     + pack_size(obj)
                     + pack_size(func)
                     + pack_size(input);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << REPLNET_CALL << nonce << obj << func << input;
     return msg;
@@ -90,7 +90,7 @@ pending_call :: resend_on_failure()
 }
 
 void
-pending_call :: handle_response(client*, std::auto_ptr<e::buffer>, e::unpacker up)
+pending_call :: handle_response(client*, std::unique_ptr<e::buffer>, e::unpacker up)
 {
     replicant_returncode st;
     e::slice output;

--- a/client/pending_call.h
+++ b/client/pending_call.h
@@ -46,10 +46,10 @@ class pending_call : public pending
         virtual ~pending_call() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_call_robust.cc
+++ b/client/pending_call_robust.cc
@@ -63,7 +63,7 @@ pending_call_robust :: ~pending_call_robust() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_call_robust :: request(uint64_t nonce)
 {
     assert(command_nonce() > 0);
@@ -78,7 +78,7 @@ pending_call_robust :: request(uint64_t nonce)
                     + pack_size(obj)
                     + pack_size(func)
                     + pack_size(input);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << REPLNET_CALL_ROBUST << nonce << command_nonce() << min_slot() << obj << func << input;
     return msg;
@@ -91,7 +91,7 @@ pending_call_robust :: resend_on_failure()
 }
 
 void
-pending_call_robust :: handle_response(client*, std::auto_ptr<e::buffer>, e::unpacker up)
+pending_call_robust :: handle_response(client*, std::unique_ptr<e::buffer>, e::unpacker up)
 {
     replicant_returncode st;
     e::slice output;

--- a/client/pending_call_robust.h
+++ b/client/pending_call_robust.h
@@ -45,10 +45,10 @@ class pending_call_robust : public pending_robust
         virtual ~pending_call_robust() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_cond_follow.cc
+++ b/client/pending_cond_follow.cc
@@ -91,7 +91,7 @@ pending_cond_follow :: ~pending_cond_follow() throw ()
     }
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_cond_follow :: request(uint64_t nonce)
 {
     e::slice obj(m_object);
@@ -102,7 +102,7 @@ pending_cond_follow :: request(uint64_t nonce)
                     + 2 * sizeof(uint64_t)
                     + pack_size(obj)
                     + pack_size(cond);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << REPLNET_COND_WAIT << nonce << obj << cond << state;
     return msg;
@@ -115,7 +115,7 @@ pending_cond_follow :: resend_on_failure()
 }
 
 void
-pending_cond_follow :: handle_response(client* cl, std::auto_ptr<e::buffer>, e::unpacker up)
+pending_cond_follow :: handle_response(client* cl, std::unique_ptr<e::buffer>, e::unpacker up)
 {
     uint64_t state;
     e::slice data;

--- a/client/pending_cond_follow.h
+++ b/client/pending_cond_follow.h
@@ -50,10 +50,10 @@ class pending_cond_follow : public pending
         virtual ~pending_cond_follow() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_cond_wait.cc
+++ b/client/pending_cond_wait.cc
@@ -58,7 +58,7 @@ pending_cond_wait :: ~pending_cond_wait() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_cond_wait :: request(uint64_t nonce)
 {
     e::slice obj(m_object);
@@ -68,7 +68,7 @@ pending_cond_wait :: request(uint64_t nonce)
                     + 2 * sizeof(uint64_t)
                     + pack_size(obj)
                     + pack_size(cond);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << REPLNET_COND_WAIT << nonce << obj << cond << m_state;
     return msg;
@@ -81,7 +81,7 @@ pending_cond_wait :: resend_on_failure()
 }
 
 void
-pending_cond_wait :: handle_response(client*, std::auto_ptr<e::buffer>, e::unpacker up)
+pending_cond_wait :: handle_response(client*, std::unique_ptr<e::buffer>, e::unpacker up)
 {
     uint64_t state;
     e::slice data;

--- a/client/pending_cond_wait.h
+++ b/client/pending_cond_wait.h
@@ -44,10 +44,10 @@ class pending_cond_wait : public pending
         virtual ~pending_cond_wait() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_defended_call.cc
+++ b/client/pending_defended_call.cc
@@ -56,7 +56,7 @@ pending_defended_call :: ~pending_defended_call() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_defended_call :: request(uint64_t nonce)
 {
     std::string input;
@@ -78,7 +78,7 @@ pending_defended_call :: request(uint64_t nonce)
                     + pack_size(obj)
                     + pack_size(func)
                     + pack_size(e::slice(input));
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE)
         << REPLNET_CALL_ROBUST << nonce << command_nonce() << min_slot() << obj << func << e::slice(input);
     return msg;
@@ -91,7 +91,7 @@ pending_defended_call :: resend_on_failure()
 }
 
 void
-pending_defended_call :: handle_response(client* cl, std::auto_ptr<e::buffer>, e::unpacker up)
+pending_defended_call :: handle_response(client* cl, std::unique_ptr<e::buffer>, e::unpacker up)
 {
     replicant_returncode st;
     e::slice output;

--- a/client/pending_defended_call.h
+++ b/client/pending_defended_call.h
@@ -46,10 +46,10 @@ class pending_defended_call : public pending_robust
         virtual ~pending_defended_call() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_generate_unique_number.cc
+++ b/client/pending_generate_unique_number.cc
@@ -46,13 +46,13 @@ pending_generate_unique_number :: ~pending_generate_unique_number() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_generate_unique_number :: request(uint64_t nonce)
 {
     const size_t sz = BUSYBEE_HEADER_SIZE
                     + pack_size(REPLNET_UNIQUE_NUMBER)
                     + sizeof(uint64_t);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE) << REPLNET_UNIQUE_NUMBER << nonce;
     return msg;
 }
@@ -65,7 +65,7 @@ pending_generate_unique_number :: resend_on_failure()
 
 void
 pending_generate_unique_number :: handle_response(client*,
-                                                  std::auto_ptr<e::buffer>,
+                                                  std::unique_ptr<e::buffer>,
                                                   e::unpacker up)
 {
     up = up >> *m_number;

--- a/client/pending_generate_unique_number.h
+++ b/client/pending_generate_unique_number.h
@@ -42,10 +42,10 @@ class pending_generate_unique_number : public pending
         virtual ~pending_generate_unique_number() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/client/pending_poke.cc
+++ b/client/pending_poke.cc
@@ -43,13 +43,13 @@ pending_poke :: ~pending_poke() throw ()
 {
 }
 
-std::auto_ptr<e::buffer>
+std::unique_ptr<e::buffer>
 pending_poke :: request(uint64_t nonce)
 {
     const size_t sz = BUSYBEE_HEADER_SIZE
                     + pack_size(REPLNET_POKE)
                     + sizeof(uint64_t);
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
     msg->pack_at(BUSYBEE_HEADER_SIZE) << REPLNET_POKE << nonce;
     return msg;
 }
@@ -61,7 +61,7 @@ pending_poke :: resend_on_failure()
 }
 
 void
-pending_poke :: handle_response(client*, std::auto_ptr<e::buffer>, e::unpacker)
+pending_poke :: handle_response(client*, std::unique_ptr<e::buffer>, e::unpacker)
 {
     this->success();
 }

--- a/client/pending_poke.h
+++ b/client/pending_poke.h
@@ -41,10 +41,10 @@ class pending_poke : public pending
         virtual ~pending_poke() throw ();
 
     public:
-        virtual std::auto_ptr<e::buffer> request(uint64_t nonce);
+        virtual std::unique_ptr<e::buffer> request(uint64_t nonce);
         virtual bool resend_on_failure();
         virtual void handle_response(client* cl,
-                                     std::auto_ptr<e::buffer> msg,
+                                     std::unique_ptr<e::buffer> msg,
                                      e::unpacker up);
 
     private:

--- a/common/bootstrap.cc
+++ b/common/bootstrap.cc
@@ -148,7 +148,7 @@ replicant :: start_bootstrap(busybee_client* cl, const std::vector<po6::net::hos
     {
         const size_t sz = BUSYBEE_HEADER_SIZE
                         + pack_size(REPLNET_BOOTSTRAP);
-        std::auto_ptr<e::buffer> msg(e::buffer::create(sz));
+        std::unique_ptr<e::buffer> msg(e::buffer::create(sz));
         msg->pack_at(BUSYBEE_HEADER_SIZE) << REPLNET_BOOTSTRAP;
         po6::net::location loc = hosts[i].lookup(AF_UNSPEC, IPPROTO_TCP);
 
@@ -160,7 +160,7 @@ replicant :: start_bootstrap(busybee_client* cl, const std::vector<po6::net::hos
             continue;
         }
 
-        switch (cl->send_anonymous(loc, msg))
+        switch (cl->send_anonymous(loc, std::move(msg)))
         {
             case BUSYBEE_SUCCESS:
                 ++sent;
@@ -292,7 +292,7 @@ bootstrap :: do_it(int timeout, configuration* config, e::error* err)
         }
 
         uint64_t id = 0;
-        std::auto_ptr<e::buffer> msg;
+        std::unique_ptr<e::buffer> msg;
         assert(start <= now);
         int t = timeout - (now - start) / PO6_MILLIS + 10;
         busybee_returncode brc = m_busybee->recv(timeout > 0 ? t/10 : timeout, &id, &msg);

--- a/common/bootstrap.h
+++ b/common/bootstrap.h
@@ -85,7 +85,7 @@ class bootstrap
     private:
         std::vector<po6::net::hostname> m_hosts;
         busybee_controller m_busybee_controller;
-        const std::auto_ptr<busybee_client> m_busybee;
+        const std::unique_ptr<busybee_client> m_busybee;
         bool m_valid;
 };
 

--- a/daemon/acceptor.h
+++ b/daemon/acceptor.h
@@ -71,7 +71,7 @@ class acceptor
         uint64_t sync_cut();
         bool record_snapshot(uint64_t slot, const e::slice& snapshot);
         bool load_latest_snapshot(e::slice* snapshot,
-                                  std::auto_ptr<e::buffer>* snapshot_backing);
+                                  std::unique_ptr<e::buffer>* snapshot_backing);
 
     private:
         struct log_segment;
@@ -96,9 +96,9 @@ class acceptor
         po6::io::fd m_lock;
         uint64_t m_opcount;
         bool m_permafail;
-        std::auto_ptr<log_segment> m_current;
-        std::auto_ptr<log_segment> m_previous;
-        const std::auto_ptr<garbage_collector> m_gc;
+        std::unique_ptr<log_segment> m_current;
+        std::unique_ptr<log_segment> m_previous;
+        const std::unique_ptr<garbage_collector> m_gc;
 };
 
 END_REPLICANT_NAMESPACE

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -95,43 +95,43 @@ class daemon
     public:
         void become_cluster_member(bootstrap bs);
         void setup_replica_from_bootstrap(bootstrap bs,
-                                          std::auto_ptr<replica>* rep);
+                                          std::unique_ptr<replica>* rep);
         void send_bootstrap(server_id si);
         void process_bootstrap(server_id si,
-                               std::auto_ptr<e::buffer> msg,
+                               std::unique_ptr<e::buffer> msg,
                                e::unpacker up);
         void process_state_transfer(server_id si,
-                                    std::auto_ptr<e::buffer> msg,
+                                    std::unique_ptr<e::buffer> msg,
                                     e::unpacker up);
         void process_who_are_you(server_id si,
-                                 std::auto_ptr<e::buffer> msg,
+                                 std::unique_ptr<e::buffer> msg,
                                  e::unpacker up);
 
     // core Paxos protocol in steady state
     public:
         void send_paxos_phase1a(server_id to, const ballot& b);
         void process_paxos_phase1a(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void send_paxos_phase1b(server_id to);
         void process_paxos_phase1b(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void send_paxos_phase2a(server_id to, const pvalue& pval);
         void process_paxos_phase2a(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void send_paxos_phase2b(server_id to, const pvalue& pval);
         void process_paxos_phase2b(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void send_paxos_learn(server_id to, const pvalue& pval);
         void process_paxos_learn(server_id si,
-                                 std::auto_ptr<e::buffer> msg,
+                                 std::unique_ptr<e::buffer> msg,
                                  e::unpacker up);
         void send_paxos_submit(uint64_t slot_start, uint64_t slot_limit, const e::slice& command);
         void process_paxos_submit(server_id si,
-                                  std::auto_ptr<e::buffer> msg,
+                                  std::unique_ptr<e::buffer> msg,
                                   e::unpacker up);
         void enqueue_paxos_command(slot_type t,
                                    const std::string& command);
@@ -160,25 +160,25 @@ class daemon
     public:
         std::string construct_become_member_command(const server& s);
         void process_server_become_member(server_id si,
-                                          std::auto_ptr<e::buffer> msg,
+                                          std::unique_ptr<e::buffer> msg,
                                           e::unpacker up);
         void periodic_check_address(uint64_t now);
 
     // Nonce-oriented stuff
     public:
         void process_unique_number(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void periodic_generate_nonce_sequence(uint64_t now);
         void callback_nonce_sequence(server_id si, uint64_t token, uint64_t counter);
         bool generate_nonce(uint64_t* nonce);
         void process_when_nonces_available(server_id si,
-                                           std::auto_ptr<e::buffer> msg);
+                                           std::unique_ptr<e::buffer> msg);
 
     // Dead objects?
     public:
         void process_object_failed(server_id si,
-                                   std::auto_ptr<e::buffer> msg,
+                                   std::unique_ptr<e::buffer> msg,
                                    e::unpacker up);
         void periodic_maintain_objects(uint64_t now);
 
@@ -198,19 +198,19 @@ class daemon
     // Client-library calls
     public:
         void process_poke(server_id si,
-                          std::auto_ptr<e::buffer> msg,
+                          std::unique_ptr<e::buffer> msg,
                           e::unpacker up);
         void process_cond_wait(server_id si,
-                               std::auto_ptr<e::buffer> msg,
+                               std::unique_ptr<e::buffer> msg,
                                e::unpacker up);
         void process_call(server_id si,
-                          std::auto_ptr<e::buffer> msg,
+                          std::unique_ptr<e::buffer> msg,
                           e::unpacker up);
         void process_get_robust_params(server_id si,
-                                       std::auto_ptr<e::buffer> msg,
+                                       std::unique_ptr<e::buffer> msg,
                                        e::unpacker up);
         void process_call_robust(server_id si,
-                                 std::auto_ptr<e::buffer> msg,
+                                 std::unique_ptr<e::buffer> msg,
                                  e::unpacker up);
         void periodic_tick(uint64_t now);
 
@@ -218,11 +218,11 @@ class daemon
     public:
         void send_ping(server_id si);
         void process_ping(server_id si,
-                          std::auto_ptr<e::buffer> msg,
+                          std::unique_ptr<e::buffer> msg,
                           e::unpacker up);
         void send_pong(server_id si);
         void process_pong(server_id si,
-                          std::auto_ptr<e::buffer> msg,
+                          std::unique_ptr<e::buffer> msg,
                           e::unpacker up);
         void periodic_ping_servers(uint64_t now);
 
@@ -230,9 +230,9 @@ class daemon
         void rebootstrap(bootstrap b);
 
     public:
-        bool send(server_id si, std::auto_ptr<e::buffer> msg);
-        bool send_from_non_main_thread(server_id si, std::auto_ptr<e::buffer> msg);
-        bool send_when_acceptor_persistent(server_id si, std::auto_ptr<e::buffer> msg);
+        bool send(server_id si, std::unique_ptr<e::buffer> msg);
+        bool send_from_non_main_thread(server_id si, std::unique_ptr<e::buffer> msg);
+        bool send_when_acceptor_persistent(server_id si, std::unique_ptr<e::buffer> msg);
         void flush_acceptor_messages();
 
     public:
@@ -263,7 +263,7 @@ class daemon
         std::vector<periodic> m_periodic;
 
         // Bootstrap when every node in the cluster has changed its address
-        std::auto_ptr<po6::threads::thread> m_bootstrap_thread;
+        std::unique_ptr<po6::threads::thread> m_bootstrap_thread;
         uint32_t m_bootstrap_stop;
 
         // generate unique numbers, using a counter in the replica
@@ -289,10 +289,10 @@ class daemon
 
         // paxos state
         acceptor m_acceptor;
-        std::auto_ptr<scout> m_scout;
+        std::unique_ptr<scout> m_scout;
         uint64_t m_scout_wait_cycles;
-        std::auto_ptr<leader> m_leader;
-        std::auto_ptr<replica> m_replica;
+        std::unique_ptr<leader> m_leader;
+        std::unique_ptr<replica> m_replica;
         uint64_t m_last_replica_snapshot; // XXX remove
         uint64_t m_last_gc_slot; // XXX remove
 };

--- a/daemon/object.cc
+++ b/daemon/object.cc
@@ -273,7 +273,7 @@ object :: rtor(e::unpacker up)
     for (uint64_t i = 0; i < cond_size; ++i)
     {
         e::slice s;
-        std::auto_ptr<condition> c(new condition());
+        std::unique_ptr<condition> c(new condition());
         up = up >> s >> *c;
         m_conditions[s.str()] = c.get();
         c.release();
@@ -610,10 +610,10 @@ object :: run()
         (*it)->abort_snapshot();
     }
 
-    std::auto_ptr<e::buffer> msg(e::buffer::create(BUSYBEE_HEADER_SIZE + 8));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(BUSYBEE_HEADER_SIZE + 8));
     msg->pack_at(BUSYBEE_HEADER_SIZE) << REPLNET_OBJECT_FAILED;
     daemon* d = m_replica->m_daemon;
-    d->send_from_non_main_thread(d->id(), msg);
+    d->send_from_non_main_thread(d->id(), std::move(msg));
     po6::threads::mutex::hold hold(&m_mtx);
     m_done = true;
 }
@@ -695,7 +695,7 @@ object :: do_call(const enqueued_call& c)
     const size_t sz = sizeof(uint64_t)
                     + sizeof(uint32_t) + func.size()
                     + sizeof(uint32_t) + input.size();
-    std::auto_ptr<e::buffer> msg(e::buffer::create(sz + 1));
+    std::unique_ptr<e::buffer> msg(e::buffer::create(sz + 1));
     msg->pack_at(0)
         << uint8_t(ACTION_COMMAND)
         << uint64_t(sz)
@@ -889,7 +889,7 @@ object :: do_call_cond_create()
 
     if (it == m_conditions.end())
     {
-        std::auto_ptr<condition> c(new condition());
+        std::unique_ptr<condition> c(new condition());
         m_conditions.insert(std::make_pair(cond, c.get()));
         c.release();
     }

--- a/daemon/replica.cc
+++ b/daemon/replica.cc
@@ -377,7 +377,7 @@ replica :: strike_number(server_id si) const
 void
 replica :: take_blocking_snapshot(uint64_t* snapshot_slot,
                                   e::slice* snapshot,
-                                  std::auto_ptr<e::buffer>* snapshot_backing)
+                                  std::unique_ptr<e::buffer>* snapshot_backing)
 {
     initiate_snapshot();
     snapshot_barrier();
@@ -459,7 +459,7 @@ replica :: from_snapshot(daemon* d, const e::slice& snap)
         return NULL;
     }
 
-    std::auto_ptr<replica> rep(new replica(d, configs.front()));
+    std::unique_ptr<replica> rep(new replica(d, configs.front()));
     rep->m_slot = slot;
     rep->m_counter = counter;
     rep->m_configs = configs;
@@ -548,7 +548,7 @@ replica :: last_snapshot_num()
 void
 replica :: get_last_snapshot(uint64_t* snapshot_slot,
                              e::slice* snapshot,
-                             std::auto_ptr<e::buffer>* snapshot_backing)
+                             std::unique_ptr<e::buffer>* snapshot_backing)
 {
     bool block = false;
     m_latest_snapshot_mtx.lock();

--- a/daemon/replica.h
+++ b/daemon/replica.h
@@ -97,11 +97,11 @@ class replica
     public:
         void take_blocking_snapshot(uint64_t* snapshot_slot,
                                     e::slice* snapshot,
-                                    std::auto_ptr<e::buffer>* snapshot_backing);
+                                    std::unique_ptr<e::buffer>* snapshot_backing);
         uint64_t last_snapshot_num();
         void get_last_snapshot(uint64_t* snapshot_slot,
                                e::slice* snapshot,
-                               std::auto_ptr<e::buffer>* snapshot_backing);
+                               std::unique_ptr<e::buffer>* snapshot_backing);
         static replica* from_snapshot(daemon* d, const e::slice& snap);
 
     // recovering from object failures
@@ -246,7 +246,7 @@ class replica
         // protect the latest snapshot
         po6::threads::mutex m_latest_snapshot_mtx;
         uint64_t m_latest_snapshot_slot;
-        std::auto_ptr<e::buffer> m_latest_snapshot_backing;
+        std::unique_ptr<e::buffer> m_latest_snapshot_backing;
 
     private:
         replica(const replica&);

--- a/gremlin
+++ b/gremlin
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 "$(dirname "$0")/scripts/gremlin" "$@"

--- a/scripts/gremlin
+++ b/scripts/gremlin
@@ -502,22 +502,39 @@ class Playground(object):
         states = {}
         wait = True
         iteration = 0
+        def tcp_states():
+            files = ['/proc/net/tcp', '/proc/net/tcp6']
+            for fn in files:
+                if not os.path.exists(fn):
+                    continue
+                for line in open(fn).read().splitlines()[1:]:
+                    cols = line.split()
+                    local = cols[1]
+                    state_code = cols[3]
+                    port = int(local.split(':')[1], 16)
+                    state_map = {
+                        '01': 'ESTABLISHED',
+                        '02': 'SYN_SENT',
+                        '03': 'SYN_RECV',
+                        '04': 'FIN_WAIT1',
+                        '05': 'FIN_WAIT2',
+                        '06': 'TIME_WAIT',
+                        '07': 'CLOSE',
+                        '08': 'CLOSE_WAIT',
+                        '09': 'LAST_ACK',
+                        '0A': 'LISTEN',
+                        '0B': 'CLOSING'
+                    }
+                    state = state_map.get(state_code, 'UNKNOWN')
+                    yield port, state
         while wait:
             wait = False
-            stdout = subprocess.check_output(('netstat', '-an'))
-            stdout = stdout.decode('utf8', 'ignore')
-            for x in re.findall('^tcp.*$', stdout, flags=re.MULTILINE):
-                x = re.sub('\s+', ' ', x).split(' ')
-                port = x[3].rsplit(':', 1)[-1]
-                try:
-                    port = int(port, 10)
-                except ValueError:
-                    raise GremlinError('error parsing netstat output')
-                state = x[5]
+            states = {}
+            for port, state in tcp_states():
                 states[port] = state
                 if port in ports and state != 'TIME_WAIT':
                     wait = True
-            if wait and all([x in ('LISTEN', 'ESTABLISHED') for x in list(states.values())]):
+            if wait and states and all([s in ('LISTEN', 'ESTABLISHED') for s in states.values()]):
                 raise GremlinError('ports in use by other processes')
             if wait:
                 time.sleep(0.1)
@@ -571,7 +588,12 @@ class Playground(object):
         env.update(self.environment)
         if 'GREMLIN_PREFIX' not in env:
             return ()
-        return tuple(shlex.split(env['GREMLIN_PREFIX'], posix=True))
+        args = shlex.split(env['GREMLIN_PREFIX'], posix=True)
+        if 'valgrind' in args and shutil.which('valgrind') is None:
+            print('valgrind not found; running without it')
+            idx = args.index('valgrind')
+            args = args[:idx]  # drop valgrind and all later args
+        return tuple(args)
 
 def main(todo):
     try:


### PR DESCRIPTION
## Notes
- make now passes without valgrind installed

## Summary
- added wrapper script so gremlin is on PATH
- gremlin script skips valgrind if unavailable
- replaced deprecated `auto_ptr` with `unique_ptr`
- updated code to use move semantics
- `make check` now succeeds
