### PR TITLE
Add valgrind to setup script

### DIFF
--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -6,7 +6,7 @@ apt update -y
 apt install -y build-essential autoconf automake libtool pkg-config \
     libgoogle-glog-dev libleveldb-dev libpopt-dev \
     libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
-    libsparsehash-dev pandoc \
+    libsparsehash-dev pandoc valgrind \
     libbsd-dev \
     autoconf-archive &
 APT_PID=$!


### PR DESCRIPTION
## Summary
- install valgrind as part of `.agent/deps.sh` to enable running tests under valgrind

## Testing
- `bash -n .agent/setup.sh`
- `bash -n .agent/deps.sh`
- `bash .agent/setup.sh` *(fails: Unable to fetch packages)*